### PR TITLE
feat: add home page filter

### DIFF
--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -1,3 +1,4 @@
 export 'data/data.dart';
+export 'domain/domain.dart';
 export 'presentation/presentation.dart';
 export 'utils/utils.dart';

--- a/lib/core/domain/domain.dart
+++ b/lib/core/domain/domain.dart
@@ -1,0 +1,1 @@
+export 'models/dropdown_item.dart';

--- a/lib/core/domain/models/dropdown_item.dart
+++ b/lib/core/domain/models/dropdown_item.dart
@@ -1,0 +1,3 @@
+mixin DropdownItem {
+  String get dropdownText;
+}

--- a/lib/core/presentation/presentation.dart
+++ b/lib/core/presentation/presentation.dart
@@ -1,4 +1,6 @@
 export 'app_cubit.dart';
 export 'widgets/errors/try_again_empty.dart';
 export 'widgets/errors/try_again_error.dart';
+export 'widgets/form_fields/app_dropdown_field.dart';
+export 'widgets/form_fields/app_text_field.dart';
 export 'widgets/loaders/center_loader.dart';

--- a/lib/core/presentation/widgets/form_fields/app_dropdown_field.dart
+++ b/lib/core/presentation/widgets/form_fields/app_dropdown_field.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import '../../../core.dart';
+
+class AppDropdownField<T extends DropdownItem> extends StatelessWidget {
+  const AppDropdownField({
+    required this.onChanged,
+    required this.items,
+    required this.label,
+    this.value,
+    super.key,
+  });
+
+  final ValueChanged<T?> onChanged;
+  final List<T> items;
+  final String label;
+  final T? value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: Text(label),
+        ),
+        Expanded(
+          flex: 3,
+          child: DropdownButtonFormField<T?>(
+            onChanged: onChanged,
+            value: value,
+            items: <DropdownMenuItem<T?>>[
+              DropdownMenuItem<T?>(
+                child: const Text('-'),
+              ),
+              ...items.map(
+                (T item) => DropdownMenuItem<T>(
+                  value: item,
+                  child: Text(item.dropdownText),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/presentation/widgets/form_fields/app_text_field.dart
+++ b/lib/core/presentation/widgets/form_fields/app_text_field.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class AppTextField extends StatelessWidget {
+  const AppTextField({
+    this.onTap,
+    this.controller,
+    this.suffixIcon,
+    required this.label,
+    this.readOnly = false,
+    super.key,
+  });
+
+  final VoidCallback? onTap;
+  final TextEditingController? controller;
+  final Widget? suffixIcon;
+  final String label;
+  final bool readOnly;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: Text(label),
+        ),
+        Expanded(
+          flex: 3,
+          child: TextFormField(
+            onTap: onTap,
+            controller: controller,
+            readOnly: readOnly,
+            decoration: InputDecoration(
+              suffixIcon: suffixIcon,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/utils/extensions/date_time_ext.dart
+++ b/lib/core/utils/extensions/date_time_ext.dart
@@ -1,5 +1,12 @@
 import 'package:intl/intl.dart';
 
 extension DateTimeExt on DateTime {
+  /// Format date to "Wed, 1/1/2025".
   String yMEd() => DateFormat.yMEd().format(this);
+
+  /// Format date to "1/1/2025".
+  String yMd() => DateFormat.yMd().format(this);
+
+  /// Format date to "2025-01-01".
+  String yyyyMMdd() => DateFormat('yyyy-MM-dd').format(this);
 }

--- a/lib/data/repositories/absences_repository.dart
+++ b/lib/data/repositories/absences_repository.dart
@@ -11,6 +11,7 @@ class AbsencesRepository {
   String get _table => SupabaseTables.absences.name;
 
   Future<Either<List<Absence>>> getAbsences({
+    AbsenceFilter? filter,
     int? userId,
   }) {
     final String memberTable = SupabaseTables.member.name;
@@ -20,6 +21,7 @@ class AbsencesRepository {
       queryParameters: <String, dynamic>{
         'select': '*,$memberTable:$memberTable!inner(*)',
         if (userId != null) 'userId': 'eq.$userId',
+        if (filter?.hasFilter ?? false) ...filter!.toQueryParam()!,
       },
       jsonListDecoder: (JsonList jsonList) =>
           jsonList.map(Absence.fromJson).toList(),

--- a/lib/domain/domain.dart
+++ b/lib/domain/domain.dart
@@ -4,6 +4,7 @@ import 'use_cases/absences_use_case.dart';
 import 'use_cases/members_use_case.dart';
 
 export 'models/absence.dart';
+export 'models/absence_filter.dart';
 export 'models/member.dart';
 export 'use_cases/absences_use_case.dart';
 export 'use_cases/members_use_case.dart';

--- a/lib/domain/models/absence.dart
+++ b/lib/domain/models/absence.dart
@@ -46,9 +46,13 @@ class Absence {
   bool get isRejected => rejectedAt != null;
 }
 
-enum AbsenceType {
+enum AbsenceType with DropdownItem {
   sickness,
   vacation,
+  ;
+
+  @override
+  String get dropdownText => name;
 }
 
 enum AbsenceStatus {

--- a/lib/domain/models/absence_filter.dart
+++ b/lib/domain/models/absence_filter.dart
@@ -1,7 +1,10 @@
+import 'package:equatable/equatable.dart';
+
 import '../../core/core.dart';
 import '../domain.dart';
 
-class AbsenceFilter {
+// ignore: must_be_immutable
+class AbsenceFilter with EquatableMixin {
   AbsenceFilter({
     this.type,
     this.startDate,
@@ -31,4 +34,11 @@ class AbsenceFilter {
       if (endDate != null) 'endDate': 'lte.${endDate!.yyyyMMdd()}',
     };
   }
+
+  @override
+  List<Object?> get props => <Object?>[
+        type,
+        startDate,
+        endDate,
+      ];
 }

--- a/lib/domain/models/absence_filter.dart
+++ b/lib/domain/models/absence_filter.dart
@@ -1,0 +1,34 @@
+import '../../core/core.dart';
+import '../domain.dart';
+
+class AbsenceFilter {
+  AbsenceFilter({
+    this.type,
+    this.startDate,
+    this.endDate,
+  });
+
+  AbsenceType? type;
+  DateTime? startDate;
+  DateTime? endDate;
+
+  bool get hasFilter => type != null || startDate != null || endDate != null;
+
+  void clear() {
+    type = null;
+    startDate = null;
+    endDate = null;
+  }
+
+  Json? toQueryParam() {
+    if (!hasFilter) {
+      return null;
+    }
+
+    return <String, dynamic>{
+      if (type != null) 'type': 'eq.${type!.name}',
+      if (startDate != null) 'startDate': 'gte.${startDate!.yyyyMMdd()}',
+      if (endDate != null) 'endDate': 'lte.${endDate!.yyyyMMdd()}',
+    };
+  }
+}

--- a/lib/domain/use_cases/absences_use_case.dart
+++ b/lib/domain/use_cases/absences_use_case.dart
@@ -7,11 +7,19 @@ class AbsencesUseCase {
 
   final AbsencesRepository absencesRepository;
 
-  Future<Either<List<Absence>>> getAllAbsences() =>
-      absencesRepository.getAbsences();
-
-  Future<Either<List<Absence>>> getAbsencesByMember(int userId) =>
+  Future<Either<List<Absence>>> getAllAbsences({
+    AbsenceFilter? filter,
+  }) =>
       absencesRepository.getAbsences(
+        filter: filter,
+      );
+
+  Future<Either<List<Absence>>> getAbsencesByMember(
+    int userId, {
+    AbsenceFilter? filter,
+  }) =>
+      absencesRepository.getAbsences(
+        filter: filter,
         userId: userId,
       );
 }

--- a/lib/presentation/pages/home/home_page.dart
+++ b/lib/presentation/pages/home/home_page.dart
@@ -4,9 +4,14 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../core/core.dart';
 import '../../../domain/domain.dart';
 import '../../widgets/cards/absence_card.dart';
+import '../../widgets/forms/absence_filter_form.dart';
 import 'view_model/home_page_vm.dart';
 
 export 'view_model/home_page_vm.dart';
+
+part 'widgets/absence_list.dart';
+part 'widgets/body.dart';
+part 'widgets/filter_section.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({
@@ -19,37 +24,7 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Absence Manager'),
       ),
-      body: BlocBuilder<HomePageVm, HomePageState>(
-        builder: (_, HomePageState state) {
-          if (state.isLoading && state.absences.isEmpty) {
-            return const CenterLoader();
-          } else if (state.error != null) {
-            return TryAgainError(
-              onTryAgain: context.read<HomePageVm>().refresh,
-              error: state.error,
-            );
-          } else if (state.absences.isEmpty) {
-            return TryAgainEmpty(
-              onRefresh: context.read<HomePageVm>().refresh,
-            );
-          }
-
-          return RefreshIndicator(
-            onRefresh: context.read<HomePageVm>().refresh,
-            child: ListView.builder(
-              itemCount: state.absences.length,
-              itemBuilder: (_, int index) {
-                final Absence absence = state.absences[index];
-
-                return AbsenceCard(
-                  key: ValueKey<int>(absence.id),
-                  absence: state.absences[index],
-                );
-              },
-            ),
-          );
-        },
-      ),
+      body: const _Body(),
     );
   }
 }

--- a/lib/presentation/pages/home/view_model/home_page_state.dart
+++ b/lib/presentation/pages/home/view_model/home_page_state.dart
@@ -9,6 +9,7 @@ part 'home_page_state.freezed.dart';
 abstract class HomePageState with _$HomePageState {
   const factory HomePageState({
     @Default(<Absence>[]) List<Absence> absences,
+    AbsenceFilter? filter,
     Failure? error,
     @Default(false) bool isLoading,
   }) = _HomePageState;

--- a/lib/presentation/pages/home/view_model/home_page_state.freezed.dart
+++ b/lib/presentation/pages/home/view_model/home_page_state.freezed.dart
@@ -16,6 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$HomePageState {
   List<Absence> get absences;
+  AbsenceFilter? get filter;
   Failure? get error;
   bool get isLoading;
 
@@ -33,6 +34,7 @@ mixin _$HomePageState {
         (other.runtimeType == runtimeType &&
             other is HomePageState &&
             const DeepCollectionEquality().equals(other.absences, absences) &&
+            (identical(other.filter, filter) || other.filter == filter) &&
             (identical(other.error, error) || other.error == error) &&
             (identical(other.isLoading, isLoading) ||
                 other.isLoading == isLoading));
@@ -40,11 +42,11 @@ mixin _$HomePageState {
 
   @override
   int get hashCode => Object.hash(runtimeType,
-      const DeepCollectionEquality().hash(absences), error, isLoading);
+      const DeepCollectionEquality().hash(absences), filter, error, isLoading);
 
   @override
   String toString() {
-    return 'HomePageState(absences: $absences, error: $error, isLoading: $isLoading)';
+    return 'HomePageState(absences: $absences, filter: $filter, error: $error, isLoading: $isLoading)';
   }
 }
 
@@ -54,7 +56,11 @@ abstract mixin class $HomePageStateCopyWith<$Res> {
           HomePageState value, $Res Function(HomePageState) _then) =
       _$HomePageStateCopyWithImpl;
   @useResult
-  $Res call({List<Absence> absences, Failure? error, bool isLoading});
+  $Res call(
+      {List<Absence> absences,
+      AbsenceFilter? filter,
+      Failure? error,
+      bool isLoading});
 }
 
 /// @nodoc
@@ -71,6 +77,7 @@ class _$HomePageStateCopyWithImpl<$Res>
   @override
   $Res call({
     Object? absences = null,
+    Object? filter = freezed,
     Object? error = freezed,
     Object? isLoading = null,
   }) {
@@ -79,6 +86,10 @@ class _$HomePageStateCopyWithImpl<$Res>
           ? _self.absences
           : absences // ignore: cast_nullable_to_non_nullable
               as List<Absence>,
+      filter: freezed == filter
+          ? _self.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as AbsenceFilter?,
       error: freezed == error
           ? _self.error
           : error // ignore: cast_nullable_to_non_nullable
@@ -96,6 +107,7 @@ class _$HomePageStateCopyWithImpl<$Res>
 class _HomePageState implements HomePageState {
   const _HomePageState(
       {final List<Absence> absences = const <Absence>[],
+      this.filter,
       this.error,
       this.isLoading = false})
       : _absences = absences;
@@ -109,6 +121,8 @@ class _HomePageState implements HomePageState {
     return EqualUnmodifiableListView(_absences);
   }
 
+  @override
+  final AbsenceFilter? filter;
   @override
   final Failure? error;
   @override
@@ -129,6 +143,7 @@ class _HomePageState implements HomePageState {
         (other.runtimeType == runtimeType &&
             other is _HomePageState &&
             const DeepCollectionEquality().equals(other._absences, _absences) &&
+            (identical(other.filter, filter) || other.filter == filter) &&
             (identical(other.error, error) || other.error == error) &&
             (identical(other.isLoading, isLoading) ||
                 other.isLoading == isLoading));
@@ -136,11 +151,11 @@ class _HomePageState implements HomePageState {
 
   @override
   int get hashCode => Object.hash(runtimeType,
-      const DeepCollectionEquality().hash(_absences), error, isLoading);
+      const DeepCollectionEquality().hash(_absences), filter, error, isLoading);
 
   @override
   String toString() {
-    return 'HomePageState(absences: $absences, error: $error, isLoading: $isLoading)';
+    return 'HomePageState(absences: $absences, filter: $filter, error: $error, isLoading: $isLoading)';
   }
 }
 
@@ -152,7 +167,11 @@ abstract mixin class _$HomePageStateCopyWith<$Res>
       __$HomePageStateCopyWithImpl;
   @override
   @useResult
-  $Res call({List<Absence> absences, Failure? error, bool isLoading});
+  $Res call(
+      {List<Absence> absences,
+      AbsenceFilter? filter,
+      Failure? error,
+      bool isLoading});
 }
 
 /// @nodoc
@@ -169,6 +188,7 @@ class __$HomePageStateCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   $Res call({
     Object? absences = null,
+    Object? filter = freezed,
     Object? error = freezed,
     Object? isLoading = null,
   }) {
@@ -177,6 +197,10 @@ class __$HomePageStateCopyWithImpl<$Res>
           ? _self._absences
           : absences // ignore: cast_nullable_to_non_nullable
               as List<Absence>,
+      filter: freezed == filter
+          ? _self.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as AbsenceFilter?,
       error: freezed == error
           ? _self.error
           : error // ignore: cast_nullable_to_non_nullable

--- a/lib/presentation/pages/home/view_model/home_page_vm.dart
+++ b/lib/presentation/pages/home/view_model/home_page_vm.dart
@@ -15,7 +15,9 @@ class HomePageVm extends AppCubit<HomePageState> {
   Future<void> getAbsences() async {
     emit(state.copyWith(isLoading: true));
 
-    final Either<List<Absence>> result = await absencesUseCase.getAllAbsences();
+    final Either<List<Absence>> result = await absencesUseCase.getAllAbsences(
+      filter: state.filter,
+    );
 
     result.handle(
       (List<Absence> l) => emit(
@@ -35,4 +37,19 @@ class HomePageVm extends AppCubit<HomePageState> {
   }
 
   Future<void> refresh() => getAbsences();
+
+  Future<void> filter(AbsenceFilter? filter) async {
+    if (state.isLoading) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        filter: filter,
+        absences: <Absence>[],
+      ),
+    );
+
+    return getAbsences();
+  }
 }

--- a/lib/presentation/pages/home/view_model/home_page_vm.dart
+++ b/lib/presentation/pages/home/view_model/home_page_vm.dart
@@ -13,6 +13,10 @@ class HomePageVm extends AppCubit<HomePageState> {
   void init() => getAbsences();
 
   Future<void> getAbsences() async {
+    if (state.isLoading) {
+      return;
+    }
+
     emit(state.copyWith(isLoading: true));
 
     final Either<List<Absence>> result = await absencesUseCase.getAllAbsences(
@@ -39,10 +43,6 @@ class HomePageVm extends AppCubit<HomePageState> {
   Future<void> refresh() => getAbsences();
 
   Future<void> filter(AbsenceFilter? filter) async {
-    if (state.isLoading) {
-      return;
-    }
-
     emit(
       state.copyWith(
         filter: filter,

--- a/lib/presentation/pages/home/widgets/absence_list.dart
+++ b/lib/presentation/pages/home/widgets/absence_list.dart
@@ -1,0 +1,42 @@
+part of '../home_page.dart';
+
+class _AbsenceList extends StatelessWidget {
+  const _AbsenceList();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<HomePageVm, HomePageState>(
+      builder: (_, HomePageState state) {
+        if (state.isLoading && state.absences.isEmpty) {
+          return const CenterLoader();
+        } else if (state.error != null) {
+          return SingleChildScrollView(
+            child: TryAgainError(
+              onTryAgain: context.read<HomePageVm>().refresh,
+              error: state.error,
+            ),
+          );
+        } else if (state.absences.isEmpty) {
+          return TryAgainEmpty(
+            onRefresh: context.read<HomePageVm>().refresh,
+          );
+        }
+
+        return RefreshIndicator(
+          onRefresh: context.read<HomePageVm>().refresh,
+          child: ListView.builder(
+            itemCount: state.absences.length,
+            itemBuilder: (_, int index) {
+              final Absence absence = state.absences[index];
+
+              return AbsenceCard(
+                key: ValueKey<int>(absence.id),
+                absence: absence,
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/pages/home/widgets/body.dart
+++ b/lib/presentation/pages/home/widgets/body.dart
@@ -1,0 +1,17 @@
+part of '../home_page.dart';
+
+class _Body extends StatelessWidget {
+  const _Body();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: <Widget>[
+        _FilterSection(),
+        Expanded(
+          child: _AbsenceList(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/pages/home/widgets/filter_section.dart
+++ b/lib/presentation/pages/home/widgets/filter_section.dart
@@ -1,0 +1,21 @@
+part of '../home_page.dart';
+
+class _FilterSection extends StatelessWidget {
+  const _FilterSection();
+
+  @override
+  Widget build(BuildContext context) {
+    return ExpansionTile(
+      title: const Text('Filter'),
+      children: <Widget>[
+        BlocSelector<HomePageVm, HomePageState, AbsenceFilter?>(
+          selector: (HomePageState state) => state.filter,
+          builder: (_, AbsenceFilter? filter) => AbsenceFilterForm(
+            onFilter: context.read<HomePageVm>().filter,
+            filter: filter,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/form_fields/absence_period_text_field.dart
+++ b/lib/presentation/widgets/form_fields/absence_period_text_field.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/core.dart';
+
+typedef OnPeriodChanged = void Function(DateTime? start, DateTime? end);
+
+class AbsencePeriodTextField extends StatefulWidget {
+  const AbsencePeriodTextField({
+    required this.onPeriodChanged,
+    this.initialStartDate,
+    this.initialEndDate,
+    super.key,
+  });
+
+  final OnPeriodChanged onPeriodChanged;
+  final DateTime? initialStartDate;
+  final DateTime? initialEndDate;
+
+  @override
+  State<StatefulWidget> createState() => _AbsencePeriodTextFieldState();
+}
+
+class _AbsencePeriodTextFieldState extends State<AbsencePeriodTextField> {
+  final TextEditingController _startDateController = TextEditingController();
+  final TextEditingController _endDateController = TextEditingController();
+
+  late DateTime? _startDate = widget.initialStartDate;
+  late DateTime? _endDate = widget.initialEndDate;
+
+  Future<void> _onShowDatePicker(BuildContext context, bool isStartDate) async {
+    final DateTime now = DateTime.now();
+    final DateTime? date = await showDatePicker(
+      context: context,
+      firstDate:
+          (isStartDate || _startDate == null) ? DateTime(1990) : _startDate!,
+      lastDate: DateTime(now.year + 1, now.month, now.day),
+      initialDate: isStartDate
+          ? (widget.initialStartDate ?? now)
+          : (widget.initialEndDate ?? now),
+      currentDate: now,
+    );
+
+    if (date == null) {
+      return;
+    }
+
+    if (isStartDate) {
+      setState(() => _startDate = date);
+      _startDateController.text = date.yMd();
+    } else {
+      setState(() => _endDate = date);
+      _endDateController.text = date.yMd();
+    }
+
+    widget.onPeriodChanged(_startDate, _endDate);
+  }
+
+  void _onClearText(bool isStartDate) {
+    if (isStartDate) {
+      setState(() => _startDate = null);
+      _startDateController.clear();
+    } else {
+      setState(() => _endDate = null);
+      _endDateController.clear();
+    }
+  }
+
+  Widget _buildClearButton(bool isStartDate) => IconButton(
+        onPressed: () => _onClearText(isStartDate),
+        icon: const Icon(Icons.close),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: AppTextField(
+            onTap: () => _onShowDatePicker(context, true),
+            controller: _startDateController,
+            label: 'Start Date',
+            readOnly: true,
+            suffixIcon: _startDate != null ? _buildClearButton(true) : null,
+          ),
+        ),
+        Expanded(
+          child: AppTextField(
+            onTap: () => _onShowDatePicker(context, false),
+            controller: _endDateController,
+            label: 'End Date',
+            readOnly: true,
+            suffixIcon: _endDate != null ? _buildClearButton(false) : null,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/form_fields/absence_type_dropdown_field.dart
+++ b/lib/presentation/widgets/form_fields/absence_type_dropdown_field.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/core.dart';
+import '../../../domain/domain.dart';
+
+class AbsenceTypeDropdownField extends StatelessWidget {
+  const AbsenceTypeDropdownField({
+    required this.onChanged,
+    this.value,
+    super.key,
+  });
+
+  final ValueChanged<AbsenceType?> onChanged;
+  final AbsenceType? value;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppDropdownField<AbsenceType>(
+      onChanged: onChanged,
+      label: 'Type',
+      value: value,
+      items: AbsenceType.values,
+    );
+  }
+}

--- a/lib/presentation/widgets/forms/absence_filter_form.dart
+++ b/lib/presentation/widgets/forms/absence_filter_form.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../../../domain/domain.dart';
+import '../form_fields/absence_period_text_field.dart';
+import '../form_fields/absence_type_dropdown_field.dart';
+
+class AbsenceFilterForm extends StatefulWidget {
+  const AbsenceFilterForm({
+    required this.onFilter,
+    this.filter,
+    super.key,
+  });
+
+  final ValueChanged<AbsenceFilter> onFilter;
+  final AbsenceFilter? filter;
+
+  @override
+  State<AbsenceFilterForm> createState() => _AbsenceFilterFormState();
+}
+
+class _AbsenceFilterFormState extends State<AbsenceFilterForm> {
+  late AbsenceFilter _filter;
+
+  @override
+  void initState() {
+    super.initState();
+    _setFilterInitialState();
+  }
+
+  @override
+  void didUpdateWidget(covariant AbsenceFilterForm oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.filter != widget.filter) {
+      _setFilterInitialState();
+    }
+  }
+
+  void _setFilterInitialState() => _filter = widget.filter ?? AbsenceFilter();
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      child: Column(
+        children: <Widget>[
+          AbsenceTypeDropdownField(
+            onChanged: (AbsenceType? type) =>
+                setState(() => _filter.type = type),
+            value: _filter.type,
+          ),
+          AbsencePeriodTextField(
+            onPeriodChanged: (DateTime? start, DateTime? end) => setState(
+              () => _filter
+                ..startDate = start
+                ..endDate = end,
+            ),
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton(
+              onPressed: () => widget.onFilter(_filter),
+              child: const Text('Filter'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   cached_network_image: ^3.4.1
   dio: ^5.8.0+1
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
   flutter_bloc: ^9.1.0

--- a/test/core/utils/extensions/date_time_ext_test.dart
+++ b/test/core/utils/extensions/date_time_ext_test.dart
@@ -12,4 +12,29 @@ void main() {
       'Tue, 12/31/2024',
     );
   });
+
+  test('[yMd] checks', () {
+    final DateTime firstDayOfYear = DateTime(2025);
+
+    expect(firstDayOfYear.yMd(), '1/1/2025');
+    expect(firstDayOfYear.add(const Duration(days: 1)).yMd(), '1/2/2025');
+    expect(
+      firstDayOfYear.subtract(const Duration(days: 1)).yMd(),
+      '12/31/2024',
+    );
+  });
+
+  test('[yyyyMMdd] checks', () {
+    final DateTime firstDayOfYear = DateTime(2025);
+
+    expect(firstDayOfYear.yyyyMMdd(), '2025-01-01');
+    expect(
+      firstDayOfYear.add(const Duration(days: 1)).yyyyMMdd(),
+      '2025-01-02',
+    );
+    expect(
+      firstDayOfYear.subtract(const Duration(days: 1)).yyyyMMdd(),
+      '2024-12-31',
+    );
+  });
 }

--- a/test/data/repositories/absences_repository_test.dart
+++ b/test/data/repositories/absences_repository_test.dart
@@ -19,6 +19,12 @@ void main() {
   group('[getAbsences] tests', () {
     const int userId = 1;
 
+    final AbsenceFilter filter = AbsenceFilter(
+      type: AbsenceType.vacation,
+      startDate: DateTime.now(),
+      endDate: DateTime.now().add(const Duration(days: 1)),
+    );
+
     tearDown(() {
       final String memberTable = SupabaseTables.member.name;
 
@@ -28,6 +34,7 @@ void main() {
           queryParameters: <String, dynamic>{
             'select': '*,$memberTable:$memberTable!inner(*)',
             'userId': 'eq.$userId',
+            ...filter.toQueryParam()!,
           },
           jsonListDecoder: any(named: 'jsonListDecoder'),
         ),
@@ -62,6 +69,7 @@ void main() {
       ).thenAnswer((_) async => Either<List<Absence>>.l(absences));
 
       final Either<List<Absence>> result = await repository.getAbsences(
+        filter: filter,
         userId: userId,
       );
 
@@ -80,6 +88,7 @@ void main() {
       ).thenAnswer((_) async => Either<List<Absence>>.r(failure));
 
       final Either<List<Absence>> result = await repository.getAbsences(
+        filter: filter,
         userId: userId,
       );
 

--- a/test/domain/use_cases/absences_use_case_test.dart
+++ b/test/domain/use_cases/absences_use_case_test.dart
@@ -15,8 +15,18 @@ void main() {
   });
 
   group('[getAllAbsences] tests', () {
+    final AbsenceFilter filter = AbsenceFilter(
+      type: AbsenceType.vacation,
+      startDate: DateTime.now(),
+      endDate: DateTime.now().add(const Duration(days: 1)),
+    );
+
     tearDown(() {
-      verify(() => absencesRepository.getAbsences()).called(1);
+      verify(
+        () => absencesRepository.getAbsences(
+          filter: filter,
+        ),
+      ).called(1);
       verifyNoMoreInteractions(absencesRepository);
     });
 
@@ -38,10 +48,17 @@ void main() {
         ),
       );
 
-      when(() => absencesRepository.getAbsences())
-          .thenAnswer((_) async => Either<List<Absence>>.l(absences));
+      when(
+        () => absencesRepository.getAbsences(
+          filter: any(
+            named: 'filter',
+          ),
+        ),
+      ).thenAnswer((_) async => Either<List<Absence>>.l(absences));
 
-      final Either<List<Absence>> result = await useCase.getAllAbsences();
+      final Either<List<Absence>> result = await useCase.getAllAbsences(
+        filter: filter,
+      );
 
       expect(result.l, absences);
     });
@@ -49,10 +66,17 @@ void main() {
     test('Failure', () async {
       const Failure failure = Failure();
 
-      when(() => absencesRepository.getAbsences())
-          .thenAnswer((_) async => Either<List<Absence>>.r(failure));
+      when(
+        () => absencesRepository.getAbsences(
+          filter: any(
+            named: 'filter',
+          ),
+        ),
+      ).thenAnswer((_) async => Either<List<Absence>>.r(failure));
 
-      final Either<List<Absence>> result = await useCase.getAllAbsences();
+      final Either<List<Absence>> result = await useCase.getAllAbsences(
+        filter: filter,
+      );
 
       expect(result.r, failure);
     });
@@ -61,9 +85,16 @@ void main() {
   group('[getAllAbsences] tests', () {
     const int memberUserId = 1;
 
+    final AbsenceFilter filter = AbsenceFilter(
+      type: AbsenceType.vacation,
+      startDate: DateTime.now(),
+      endDate: DateTime.now().add(const Duration(days: 1)),
+    );
+
     tearDown(() {
       verify(
         () => absencesRepository.getAbsences(
+          filter: filter,
           userId: memberUserId,
         ),
       ).called(1);
@@ -90,12 +121,15 @@ void main() {
 
       when(
         () => absencesRepository.getAbsences(
+          filter: any(named: 'filter'),
           userId: any(named: 'userId'),
         ),
       ).thenAnswer((_) async => Either<List<Absence>>.l(absences));
 
-      final Either<List<Absence>> result =
-          await useCase.getAbsencesByMember(memberUserId);
+      final Either<List<Absence>> result = await useCase.getAbsencesByMember(
+        memberUserId,
+        filter: filter,
+      );
 
       expect(result.l, absences);
     });
@@ -105,12 +139,15 @@ void main() {
 
       when(
         () => absencesRepository.getAbsences(
+          filter: any(named: 'filter'),
           userId: any(named: 'userId'),
         ),
       ).thenAnswer((_) async => Either<List<Absence>>.r(failure));
 
-      final Either<List<Absence>> result =
-          await useCase.getAbsencesByMember(memberUserId);
+      final Either<List<Absence>> result = await useCase.getAbsencesByMember(
+        memberUserId,
+        filter: filter,
+      );
 
       expect(result.r, failure);
     });

--- a/test/presentation/widgets/form_fields/absence_type_dropdown_field_test.dart
+++ b/test/presentation/widgets/form_fields/absence_type_dropdown_field_test.dart
@@ -1,0 +1,102 @@
+import 'package:absence_manager/core/core.dart';
+import 'package:absence_manager/domain/domain.dart';
+import 'package:absence_manager/presentation/widgets/form_fields/absence_type_dropdown_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../build_widget.dart';
+
+void main() {
+  Future<void> build(
+    WidgetTester tester, {
+    ValueChanged<AbsenceType?>? onChanged,
+    AbsenceType? value,
+  }) =>
+      buildWidget(
+        tester,
+        AbsenceTypeDropdownField(
+          onChanged: onChanged ?? (_) {},
+          value: value,
+        ),
+      );
+
+  group('[UI checks]', () {
+    testWidgets('Initial display', (WidgetTester tester) async {
+      await build(tester);
+
+      expect(
+        find.widgetWithText(AppDropdownField<AbsenceType>, '-'),
+        findsOneWidget,
+      );
+
+      for (final AbsenceType type in AbsenceType.values) {
+        expect(
+          find.widgetWithText(AppDropdownField<AbsenceType>, type.dropdownText),
+          findsNothing,
+        );
+      }
+    });
+
+    testWidgets('Can set initial value', (WidgetTester tester) async {
+      await build(
+        tester,
+        value: AbsenceType.sickness,
+      );
+
+      expect(
+        find.widgetWithText(AppDropdownField<AbsenceType>, '-'),
+        findsNothing,
+      );
+
+      for (final AbsenceType type in AbsenceType.values) {
+        expect(
+          find.widgetWithText(AppDropdownField<AbsenceType>, type.dropdownText),
+          type == AbsenceType.sickness ? findsOneWidget : findsNothing,
+        );
+      }
+    });
+  });
+
+  group('[Event checks]', () {
+    testWidgets(
+      'Tapping dropdown will show items',
+      (WidgetTester tester) async {
+        await build(tester);
+        await tester.tap(find.byType(AppDropdownField<AbsenceType>));
+        await tester.pumpAndSettle();
+
+        expect(find.text('-'), findsNWidgets(2));
+
+        for (final AbsenceType type in AbsenceType.values) {
+          expect(find.text(type.dropdownText), findsOneWidget);
+        }
+      },
+    );
+
+    testWidgets(
+      'Selecting new value should close dropdown',
+      (WidgetTester tester) async {
+        await build(tester);
+        await tester.tap(find.byType(AppDropdownField<AbsenceType>));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(AbsenceType.sickness.dropdownText));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.widgetWithText(AppDropdownField<AbsenceType>, '-'),
+          findsNothing,
+        );
+
+        for (final AbsenceType type in AbsenceType.values) {
+          expect(
+            find.widgetWithText(
+              AppDropdownField<AbsenceType>,
+              type.dropdownText,
+            ),
+            type == AbsenceType.sickness ? findsOneWidget : findsNothing,
+          );
+        }
+      },
+    );
+  });
+}

--- a/test/presentation/widgets/forms/absence_filter_form_test.dart
+++ b/test/presentation/widgets/forms/absence_filter_form_test.dart
@@ -1,0 +1,50 @@
+import 'package:absence_manager/domain/domain.dart';
+import 'package:absence_manager/presentation/widgets/form_fields/absence_period_text_field.dart';
+import 'package:absence_manager/presentation/widgets/form_fields/absence_type_dropdown_field.dart';
+import 'package:absence_manager/presentation/widgets/forms/absence_filter_form.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../build_widget.dart';
+
+void main() {
+  Future<void> build(
+    WidgetTester tester, {
+    ValueChanged<AbsenceFilter?>? onFilter,
+    AbsenceFilter? filter,
+  }) =>
+      buildWidget(
+        tester,
+        AbsenceFilterForm(
+          onFilter: onFilter ?? (_) {},
+          filter: filter,
+        ),
+      );
+
+  group('[UI checks]', () {
+    testWidgets('Initial display', (WidgetTester tester) async {
+      await build(tester);
+
+      expect(find.byType(AbsenceTypeDropdownField), findsOneWidget);
+      expect(find.byType(AbsencePeriodTextField), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Filter'), findsOneWidget);
+    });
+  });
+
+  group('[Event checks]', () {
+    testWidgets(
+      'Tapping filter button will trigger callback',
+      (WidgetTester tester) async {
+        bool isFilter = false;
+
+        await build(
+          tester,
+          onFilter: (_) => isFilter = true,
+        );
+        await tester.tap(find.widgetWithText(TextButton, 'Filter'));
+
+        expect(isFilter, true);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Add filter section in `HomePage`.

Collapsed filter section:
<img width="332" alt="image" src="https://github.com/user-attachments/assets/b3c1a03a-dff1-4147-a2e6-f168a97f4c5c" />

Expanded filter section:
<img width="332" alt="image" src="https://github.com/user-attachments/assets/1aac9ed6-7051-4118-8a55-eb38a74fe8c9" />


## Reviewer Checklist

- [ ] List at least one Jira ticket that this PR fixes in the description above.
- [x] Updated/Added relevant documentation (doc comments with `///`).
- [x] Added unit testing. (scenarios: successful, empty, failure, retry, refresh)
- [x] Added widget testing. (scenarios: successful, empty, failure, retry, refresh)
- [x] Added page testing. (scenarios: successful, empty, failure, retry, refresh)
- [ ] Added integration testing, if needed.
- [x] Added UI for successful, empty, failure, retry and refresh scenarios in page/screen.